### PR TITLE
fix addTMB for python3

### DIFF
--- a/tmb/calculate_tmb/calc_nonsyn_tmb.py
+++ b/tmb/calculate_tmb/calc_nonsyn_tmb.py
@@ -206,7 +206,7 @@ def calcTMB(_sampleMap):
 ######
 def addTMB(_inputStudyFolder, _sampleTmbMap):
 
-	# extract list of sequenced smaple IDs
+	# extract list of sequenced sample IDs
 	_seqSampleIds = [] 
 	if os.path.isfile(_inputStudyFolder + "/case_lists/" + SEQ_CASE_LIST_FILE_NAME):
 		_caseListPath = _inputStudyFolder + "/case_lists/" + SEQ_CASE_LIST_FILE_NAME
@@ -253,7 +253,7 @@ def addTMB(_inputStudyFolder, _sampleTmbMap):
 			# values
 			else: 
 				_sampleID = _line.split("\t")[_posSampleID]
-				if _sampleTmbMap.has_key(_sampleID):
+				if _sampleID in _sampleTmbMap:
 					_newline = _line.rstrip("\n") + "\t" + str(_sampleTmbMap[_sampleID]["tmb"])
 				else:
 					if _sampleID in _seqSampleIds:


### PR DESCRIPTION
This is a minor typo fix and code fix as has_key was removed in Python 3. From the [documentation](https://docs.python.org/3.0/whatsnew/3.0.html#builtins)

- Removed. dict.has_key() – use the [in](https://docs.python.org/3.0/reference/expressions.html#in) operator instead.
